### PR TITLE
gh-21: Enabled parsing the list of videoIds in the URL

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,17 +8,22 @@
         width: 100%;
         height: 100%;
         border: none;
+        background-color: black;
+        color: white;
       }
 
       #player {
         width: 100%;
         height: 100%;
         display: block;
+        background-color: black;
+        color: white;
       }
     </style>
   </head>
   <body>
-    <div id="player"></div>
+    <div id="player">
+    </div>
     <script src="./script.js"></script>
   </body>
 </html>

--- a/client/script.js
+++ b/client/script.js
@@ -2,8 +2,6 @@ var tag = document.createElement('script');
 
 var count  = 0 ;
 
-var videoIds = ["afvT1c1ii0c","7eRgtOIQ1OY","iITs75Izm2Y","F8C5orQdxb8"]
-
 tag.src = "https://www.youtube.com/iframe_api";
 var firstScriptTag = document.getElementsByTagName('script')[0];
 firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
@@ -11,6 +9,17 @@ firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 var player;
 var playerElm = document.getElementById("player");
 function onYouTubeIframeAPIReady() {
+  var hash = window.location.hash;
+
+  if (hash && hash.length > 0) {
+    var videoIds = hash.substr(1).split(",");
+    openPlayer(videoIds);
+  } else {
+    openPlayer([]);
+  }
+}
+
+function openPlayer(videoIds) {
   player = new YT.Player('player', {
     height: playerElm.offsetHeight,
     width: playerElm.offsetWidth,
@@ -21,31 +30,31 @@ function onYouTubeIframeAPIReady() {
       'onStateChange': onPlayerStateChange
     }
   });
-}
 
-function onPlayerReady(event) {
-  event.target.playVideo();
-  count++;
-}
-
-var done = false;
-function onPlayerStateChange(event) {
-  if (event.data == YT.PlayerState.PLAYING && !done) {
-    setTimeout(stopVideo, 6000);
-    done = true;
+  function onPlayerReady(event) {
+    event.target.playVideo();
+    count++;
   }
 
-  if(event.data ==YT.PlayerState.ENDED){
-    player.loadVideoById(videoIds[count], 0, "large");
-    player.playVideo();
-    count++;
+  var done = false;
+  function onPlayerStateChange(event) {
+    if (event.data == YT.PlayerState.PLAYING && !done) {
+      setTimeout(stopVideo, 6000);
+      done = true;
+    }
 
-    if(videoIds.length  == count){
-      count =0;
+    if(event.data ==YT.PlayerState.ENDED){
+      player.loadVideoById(videoIds[count], 0, "large");
+      player.playVideo();
+      count++;
+
+      if(videoIds.length  == count){
+        count =0;
+      }
     }
   }
-}
 
-function stopVideo() {
-  player.stopVideo();
+  function stopVideo() {
+    player.stopVideo();
+  }
 }


### PR DESCRIPTION
Fixes issue #21 

Changes: 
This has enabled parsing a list of videoIds with the URL as a comma separated string as follows.

Demo Link: 
`http://localhost:3000/#,7eRgtOIQ1OY,iITs75Izm2Y,F8C5orQdxb8`

Screenshots for the change: 
